### PR TITLE
Add instructions on using kubectl

### DIFF
--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -89,6 +89,57 @@ Here are some links to introductory Kubernetes resources:
 
 ## Interact with the cluster with `kubectl`
 
+This acts as a quick reference to kubectl, listing some of the most common operations.
+
+The examples here only address the most basic approach to these operations. For more options, please refer to the command-line help of kubectl subcommands, which you can access like this:
+```
+kubectl get --help
+```
+
+There is also a more detailed [cheatsheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/) in the official kubernetes documentation.
+
+### Inspecting running instances of an application
+
+To list running Pods:
+```
+$ kubectl -n <namespace> get pods
+```
+
+To view details for a Pod:
+```
+$ kubectl -n <namespace> describe pod <pod>
+```
+
+### Viewing logs
+
+To access the logs of a running container:
+```
+$ kubectl -n <namespace> logs <pod>
+```
+
+### Viewing kubernetes events
+
+To see kubernetes events, which can help debugging:
+```
+$ kubectl -n <namespace> get events
+```
+
+### Container shell
+
+You can get a shell inside a running container:
+```
+$ kubectl -n <namespace> exec -it <pod> sh
+```
+
+For more information, click [here](https://kubernetes.io/docs/tasks/debug-application-cluster/get-shell-running-container/)
+
+### Pod port-forwarding
+
+To forward port 5000 on localhost to port 5001 in the Pod:
+```
+$ kubectl -n <namespace> port-forward <pod> 5000:5001
+```
+
 ## Continuous Integration and Continous Deployment (CI/CD)
 
 ### Github Actions (CI)


### PR DESCRIPTION
Shamelessly lifted from
https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/quick-reference.html#kubectl-quick-reference
as a first draft