### PR TITLE
Fix GitHub Workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,22 +1,14 @@
+name: deploy
 on:
   push:
-  pull_request:
-  schedule:
-    # Deploy hourly between 9am and 7pm on weekdays
-    - cron: "0 9-19 * * 1-5"
+    branches:
+      - main
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: write
     steps:
-      - name: Set commit message up front
-        id: commit_message_writer
-        run: | # `github.event.number` will be blank if this is a cron
-          if [ "${{ github.event.number }}" == "" ]; then
-            echo "::set-output name=commit_message::Hourly scheduled redeploy"
-          else
-            echo "::set-output name=commit_message::Deploy via merge"
-          fi
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -31,4 +23,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
           cname: govuk-k8s-user-docs.publishing.service.gov.uk
-          commit_message: ${{steps.commit_message_writer.outputs.commit_message}}
+          commit_message: "Deploy via merge on main"


### PR DESCRIPTION
Fix GitHub Workflow to give permissions to actions to write to the
repo, this is needed so that the generated pages can be stored.
This is now needed since at org level, there is only read access
by default for GitHub actions, see [rfc](https://docs.google.com/document/d/1IFz7E4DcWJ09giNB38fxfccU6fdW4TrQi722zztmSxs/edit)

Other changes:
1. deploy on changes on main branch, I couldn't see why there
   should be hourly deploy. I think this workflow was copied from
   govuk-developer-docs and that workflow was transferred from
   Jenkins where cron was used to build the pages.