### PR TITLE
Automatically merge Dependabot PRs to save toil.

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yaml
+++ b/.github/workflows/dependabot_auto_merge.yaml
@@ -1,0 +1,23 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
We would never not want to merge a security patch from Dependabot in this repo if the tests are passing. Having a human in the loop is a waste of time of money as well as an unnecessary security risk.

This is straight from the [example in the Dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request) but with the latest version of [dependabot/fetch-metadata](https://github.com/dependabot/fetch-metadata) and without filtering on a specific dependency.