### PR TITLE
Add troubleshooting steps for "waiting for completion of hook" issue

### DIFF
--- a/source/manage-app/manage-state/index.html.md.erb
+++ b/source/manage-app/manage-state/index.html.md.erb
@@ -6,3 +6,16 @@ review_in: 6 months
 ---
 
 # Manage state in your app
+
+## Troubleshooting
+
+### Argo Application sync stuck "waiting for completion of hook"
+
+An Argo Application may appear to be stuck syncing forever whilst waiting for the completion of a hook from a Job that not running. In this situation you may need to cancel the sync operation. You can do this from the Argo UI with following steps:
+
+1. Choose the Application tile from the list of Applications
+1. Click "Sync Status". A modal pane should slide in from the right of the screen.
+1. Click "Terminate" from the modal to cancel the sync operation
+1. Re-sync the application by clicking "Sync"
+
+This should re-initiate the sync event and recreate the job needed to complete the sync.


### PR DESCRIPTION
There is an issue whereby Argo application may appear to sync forever. This adds steps to address this issue.