### PR TITLE
Fixes from linting tool prototype

### DIFF
--- a/source/get-started/access-eks-cluster/index.html.md.erb
+++ b/source/get-started/access-eks-cluster/index.html.md.erb
@@ -7,7 +7,7 @@ review_in: 6 months
 
 # Access EKS cluster
 
-You must access the GOV.UK Kubernetes platform [EKS cluster](https://kubernetes.io/docs/concepts/overview/components/) to use the platform.
+You must access the GOV.UK Kubernetes platform [Elastic Kubernetes Sservice cluster](https://kubernetes.io/docs/concepts/overview/components/) to use the platform.
 
 To access the cluster, you must have:
 

--- a/source/get-started/access-eks-cluster/index.html.md.erb
+++ b/source/get-started/access-eks-cluster/index.html.md.erb
@@ -7,7 +7,7 @@ review_in: 6 months
 
 # Access EKS cluster
 
-You must access the GOV.UK Kubernetes platform [Elastic Kubernetes Sservice cluster](https://kubernetes.io/docs/concepts/overview/components/) to use the platform.
+You must access the GOV.UK Kubernetes platform [Elastic Kubernetes Service cluster](https://kubernetes.io/docs/concepts/overview/components/) to use the platform.
 
 To access the cluster, you must have:
 

--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -10,7 +10,7 @@ review_in: 6 months
 To start using the GOV.UK Kubernetes platform, you must:
 
 - set up tools
-- access the EKS cluster
+- access the Elastic Kubernetes Service (EKS) cluster
 - access the Continuous Implementation / Continuous Deployment (CI/CD) pipelines
 
 Once you have done this, you can use the platform to familiarise yourself with how Kubernetes works.

--- a/source/manage-app/manage-state/index.html.md.erb
+++ b/source/manage-app/manage-state/index.html.md.erb
@@ -11,7 +11,7 @@ review_in: 6 months
 
 ### Argo application sync stuck waiting for "waiting for completion of hook"
 
-An Argo application may appear to be stuck syncing forever whilst waiting for the completion of a hook from a Job that is not running. In this situation you may need to cancel the sync operation.
+An Argo application may appear to be stuck at the syncing stage, whilst waiting for the completion of a hook from a job that is not running. In this situation you may need to cancel the sync operation.
 
 You can cancel the sync operation using the Argo UI.
 


### PR DESCRIPTION
The tech writing team is testing an implementation of the [Vale linting tool](https://vale.sh/) for the tech docs.

Our implementation is located at https://github.com/sabrinaharris/linting-prototype. 

This tool currently has rules for:
- acronyms
- condescending language
- non-inclusive language
- passive voice
- racially charged terms
- sentence length

I've run the existing docs through the linting tool and have made some very minor changes based on this.