### PR TITLE
Update ExternalSecrets doc since moving the manifests.

### DIFF
--- a/source/manage-app/manage-secrets/index.html.md.erb
+++ b/source/manage-app/manage-secrets/index.html.md.erb
@@ -77,7 +77,7 @@ You can create 2 types of secret in AWS Secrets Manager:
 
 The Kubernetes `ExternalSecret` defines the mapping between the AWS Secrets Manager secret and the Kubernetes secret inside your app.
 
-1. Go to the [`external-secrets` folder in the `govuk-helm-charts` repo](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/app-config/templates/external-secrets).
+1. Go to the [`external-secrets` chart in the `govuk-helm-charts` repo](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/external-secrets/templates/).
 
 1. Select your app's folder, or create the folder if necessary.
 
@@ -90,13 +90,13 @@ The Kubernetes `ExternalSecret` defines the mapping between the AWS Secrets Mana
 
 1. Define the `ExternalSecret`, using the following format:
 
-    ```
+    ```yaml
     apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       name: <APPNAME-SECRETNAME>
       labels:
-        {{- include "app-config.labels" . | nindent 4 }}
+        {{- include "external-secrets.labels" . | nindent 4 }}
       annotations:
         kubernetes.io/description: >
           <DESCRIPTION>
@@ -117,13 +117,13 @@ The Kubernetes `ExternalSecret` defines the mapping between the AWS Secrets Mana
 
     For example, to create a secret for the Elections API for the [GOV.UK Frontend app](https://github.com/alphagov/govuk-frontend), use the following format:
 
-    ```
+    ```yaml
     apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       name: frontend-elections-api
       labels:
-        {{- include "app-config.labels" . | nindent 4 }}
+        {{- include "external-secrets.labels" . | nindent 4 }}
       annotations:
         kubernetes.io/description: >
           Credentials used by Frontend to access external Elections API service. Field names are "key" for the API key and "url" for the endpoint URL of the Elections API.
@@ -141,10 +141,10 @@ The Kubernetes `ExternalSecret` defines the mapping between the AWS Secrets Mana
 
 1. Save the `.yaml` file and merge the change.
 
-1. Check the Argo CD dashboard for the following environments to find out whether you successfully changed the `app-config` chart:
-    - [integration](https://argo.eks.integration.govuk.digital/applications/app-config)
-    - [staging](https://argo.eks.staging.govuk.digital/applications/app-config)
-    - [production](https://argo.eks.production.govuk.digital/applications/app-config)
+1. Check the Argo CD dashboard for the following environments to find out whether you successfully changed the `external-secrets` chart:
+    - [integration](https://argo.eks.integration.govuk.digital/applications/external-secrets)
+    - [staging](https://argo.eks.staging.govuk.digital/applications/external-secrets)
+    - [production](https://argo.eks.production.govuk.digital/applications/external-secrets)
 
 ## Use the Kubernetes secret inside the app
 
@@ -153,31 +153,31 @@ You have:
 - created the secret in AWS Secrets Manager
 - defined the Kubernetes `ExternalSecret`, which maps the AWS Secrets Manager secret to the Kubernetes secret inside the app
 
-Now you must use the Kubernetes secret inside the app by defining the secret in a `.yaml` file.
+Now you can use the Kubernetes secret inside the app referring to it in the app's Helm values.
 
-1. Go to the [`app-config` folder in the `govuk-helm-charts` repo](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/app-config).
+1. Go to the [`app-config` chart](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/app-config).
 
 1. Select the `values-<ENVIRONMENT>.yaml` file that you want. For example, select the `values-integration.yaml` for the integration environment.
 
-1. In this `.yaml` file, find the app that you are adding a secret to, or create the app if necessary.
+1. In this `.yaml` file, find the app that you are adding a secret to.
 
-1. Define the secret in the `.yaml` file. What you enter into this file depends on:
+1. Add a `secretKeyRef` to the app's `extraEnv`. This depends on:
     - what type of secret you selected in the AWS Secrets Manager (managed database or non-database)
     - how you defined the mapping in the Kubernetes `ExternalSecret`
 
     For example, to define a non-database secret, you would use the following format or something similar:
 
-    ```
+    ```yaml
     - name: <ENV_VAR_NAME>
-            valueFrom:
-              secretKeyRef:
-                name: <APPNAME-SECRETNAME>
-                key: <KEY>
+      valueFrom:
+        secretKeyRef:
+          name: <APPNAME-SECRETNAME>
+          key: <KEY>
     ```
 
     The `<ENV_VAR_NAME>` is the name of the environment variable whose value you want to be set to the value from the secret.
 
-    The `<APPNAME-SECRETNAME>` in this file must match the `<APPNAME-SECRETNAME>` in the `.yaml` file in the [`external-secrets` folder in the `govuk-helm-charts` repo](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/app-config/templates/external-secrets).
+    The `<APPNAME-SECRETNAME>` in this file must match the `<APPNAME-SECRETNAME>` in the `.yaml` template in the [`external-secrets` chart](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/external-secrets/templates/).
 
     The `<KEY>` must match the __Key__ in the AWS Secrets Manager secret.
 


### PR DESCRIPTION
ExternalSecrets manifests moved to a separate Helm chart in alphagov/govuk-helm-charts#823.

Also:
 - fix syntax highlighting on YAML examples
 - a few minor edits for clarity