### PR TITLE
Make link text more specific to distinguish between 'Argo' links

### DIFF
--- a/source/get-started/tutorials/app-config-deploy-helm-chart/index.html.md.erb
+++ b/source/get-started/tutorials/app-config-deploy-helm-chart/index.html.md.erb
@@ -24,7 +24,7 @@ The govuk-helm-chart repository contains configuration for how an app is deploye
 
 1. See the changes in [Argo](https://argoproj.github.io/) (a tool to help manage app deployments)
 
-    You should be able to see your changes in the manifest within [Argo](https://argo.eks.integration.govuk.digital/applications/govuk-replatform-test-app?view=tree&orphaned=false&resource=&node=argoproj.io%2FApplication%2Fcluster-services%2Fgovuk-replatform-test-app%2F0&tab=manifest)
+    You should be able to see your changes in the [manifest within Argo](https://argo.eks.integration.govuk.digital/applications/govuk-replatform-test-app?view=tree&orphaned=false&resource=&node=argoproj.io%2FApplication%2Fcluster-services%2Fgovuk-replatform-test-app%2F0&tab=manifest)
 
 1. See your message from the environment variable in the example test app
 


### PR DESCRIPTION
We have two links that say "Argo" - the former links to the Argo website, and the latter links to a manifest file rendered by the Argo UI. It's impossible to distinguish between them unless you hover over the links, so making the link text more descriptive should help.