### PR TITLE
Minor fixes to Getting Started / onboarding docs.

### DIFF
--- a/source/get-started/access-eks-cluster/index.html.md
+++ b/source/get-started/access-eks-cluster/index.html.md
@@ -12,7 +12,7 @@ You must access the GOV.UK Kubernetes platform [Elastic Kubernetes Service clust
 To access the cluster, you must have:
 
 - [installed gds-cli](https://docs.publishing.service.gov.uk/manual/get-started.html#3-install-gds-command-line-tools)
-- [gotten access to AWS](https://docs.publishing.service.gov.uk/manual/get-started.html#7-get-aws-access)
+- [obtained access to AWS](https://docs.publishing.service.gov.uk/manual/get-started.html#7-get-aws-access)
 - [accessed AWS](https://docs.publishing.service.gov.uk/manual/get-started.html#8-access-aws-for-the-first-time) using `gds-cli`
 
 You must select a role and environment to make sure you gain access to the right cluster.

--- a/source/get-started/index.html.md
+++ b/source/get-started/index.html.md
@@ -1,18 +1,16 @@
 ---
 title: Get started
 weight: 20
-last_reviewed_on: 2022-02-01
+last_reviewed_on: 2023-03-07
 review_in: 6 months
 ---
 
 # Get started
 
-To start using the GOV.UK Kubernetes platform, you must:
+To start using the GOV.UK Kubernetes platform, you should:
 
-- set up tools
-- access the Elastic Kubernetes Service (EKS) cluster
-- access the Continuous Implementation / Continuous Deployment (CI/CD) pipelines
-
-Once you have done this, you can use the platform to familiarise yourself with how Kubernetes works.
+- try the [tutorials](tutorials)
+- [set up the necessary tools](set-up-tools)
+- check that you can [access the Elastic Kubernetes Service (EKS) clusters](access-eks-cluster)
 
 Please note that the tutorials do not require any set up of the tools.

--- a/source/get-started/tutorials/index.html.md
+++ b/source/get-started/tutorials/index.html.md
@@ -1,14 +1,14 @@
 ---
 title: Tutorials
 weight: 20
-last_reviewed_on: 2022-09-06
+last_reviewed_on: 2023-03-07
 review_in: 6 months
 ---
 
 # Tutorials
 
-These are tutorials for developers to familiarise yourself with the new GOV.UK kubernetes cluster.
+These are tutorials for developers to familiarise themselves with the new GOV.UK Kubernetes cluster.
 
-- App configuration and deployment using the govuk helm chart
+- [Update an application's environment configuration](app-config-deploy-helm-chart)
 
-- Deploy a new version of the example test app, check the deployment, monitor the app on Grafana and view application logs
+- [Deploy a new version of the example test app, check the deployment, monitor the app on Grafana and view application logs](app-update-deploy-monitor-logs)


### PR DESCRIPTION
Capitalisation, phrasing, en-GB usage, minor accuracy fixes. Add links where it's inconvenient not to have them.