### PR TITLE
Correct role name

### DIFF
--- a/source/get-started/access-eks-cluster/index.html.md
+++ b/source/get-started/access-eks-cluster/index.html.md
@@ -25,7 +25,7 @@ You must select one of the following roles to access the cluster:
 
 - admin
 - poweruser
-- read-only
+- readonly
 
 The admin role:
 
@@ -37,9 +37,9 @@ The poweruser role:
 - has read-write access to a specific namespace in a specific cluster in a specific environment
 - can view everything in that namespace excluding secrets
 
-The read-only role:
+The readonly role:
 
-- has read-only access to a specific cluster in a specific environment
+- has readonly access to a specific cluster in a specific environment
 - can view everything in that cluster excluding secrets
 
 1. Open the `gds-cli`.


### PR DESCRIPTION
Tiny typo! It does say on [line 55](https://github.com/alphagov/govuk-kubernetes-cluster-user-docs/blob/9f63551c672bbb816455c85568507250a54faf44/source/get-started/access-eks-cluster/index.html.md?plain=1#L55) `<role> is the appropriate role and will be admin, poweruser or readonly`, but I didn't read that far down and got errors trying to run `eval $(gds aws govuk-integration-read-only -e --art 8h)`