### PR TITLE
Update team name and consolidate contact details.

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -38,4 +38,4 @@ show_contribution_banner: true
 github_repo: alphagov/govuk-kubernetes-cluster-user-docs
 github_branch: main
 owner_slack_workspace: gds
-default_owner_slack: '#govuk-replatforming'
+default_owner_slack: '#govuk-platform-engineering'

--- a/source/contact-platform-engineering-team.html.md
+++ b/source/contact-platform-engineering-team.html.md
@@ -1,0 +1,35 @@
+---
+title: Contact GOV.UK Platform Engineering team
+weight: 50
+last_reviewed_on: 2023-05-24
+review_in: 6 months
+---
+
+# GOV.UK Platform Engineering team
+
+Platform Engineering team (previously known as Replatforming team) looks after the Kubernetes clusters, base services, build/release/rollout automation and Helm templates for hosting the GOV.UK website.
+
+## Get in touch
+
+The rest of this page is for staff working within GDS who may want contact the Platform Engineering team.
+
+If you're outside GDS, you can get in touch via [www.gov.uk/contact](https://www.gov.uk/contact/govuk).
+
+Within GDS, you can get in touch with GOV.UK Platform Engineering team:
+
+- via email to [`govuk-platform-engineering@`](mailto:govuk-platform-engineering@digital.cabinet-office.gov.uk) (requires a digital.cabinet-office.gov.uk account)
+- via instant message in [#govuk-platform-engineering](https://gds.slack.com/channels/govuk-platform-engineering) on Slack (requires access to gds.slack.com)
+
+## What we can help with
+
+- scalability and resilience
+- troubleshooting complex problems
+- designing or improving monitoring, metrics, tracing and observability of system behaviour
+- designing new systems or backend features (APIs, information storage and processing)
+- designing or retrofitting applications for graceful degradation under failure conditions or overload
+- migrating applications to Kubernetes from legacy systems
+- assessing whether GOV.UK's Kubernetes offering would suit your application or workload
+- application load testing and stress testing
+- capacity planning
+- advice on how to structure or maintain Terraform modules for managing cloud resources
+- continuous deployment and continuous delivery (CI/CD), build and release automation

--- a/source/fix-app/index.html.md
+++ b/source/fix-app/index.html.md
@@ -79,7 +79,7 @@ An app may face issues if the cluster has a problem. Possible issues you might e
 - a configuration problem with the cluster due to some recent change
 - a problem with a controller which might prevent an app's actual configuration from converging with its specified configuration
 
-If you suspect a problem with the cluster, [contact #govuk-replatforming on Slack](https://gds.slack.com/archives/C013F737737) to ask for help.
+If you suspect a problem with the cluster, [contact Platform Engineering team](/contact-platform-engineering-team.html) to ask for help.
 
 ## General debugging
 

--- a/source/get-started/tutorials/app-config-deploy-helm-chart/index.html.md
+++ b/source/get-started/tutorials/app-config-deploy-helm-chart/index.html.md
@@ -1,7 +1,7 @@
 ---
 title: Update an application's environment configuration
 weight: 20
-last_reviewed_on: 2023-03-07
+last_reviewed_on: 2023-05-24
 review_in: 6 months
 ---
 
@@ -21,9 +21,9 @@ The govuk-helm-chart repository contains configuration for how an app is deploye
 
 1. Deploying the changes to the app
 
-    Create the pull request (PR) on your branch, your changes will get posted automatically to the #govuk-replatforming channel for review by a member of the team. After your PR has been approved and passed status checks you can merge your PR.
+    Create the pull request (PR) on your branch. Your changes will get posted automatically to the #govuk-platform-engineering Slack channel for review by a member of the team. After your PR has been approved and passed status checks you can merge your PR.
 
-1. See the changes in [Argo](https://argoproj.github.io/) (a tool to help manage app deployments)
+1. See the changes in [Argo CD](https://argoproj.github.io/cd/) (a tool to help manage app deployments)
 
     You should be able to see your changes in the [manifest within Argo](https://argo.eks.integration.govuk.digital/applications/govuk-replatform-test-app?view=tree&orphaned=false&resource=&node=argoproj.io%2FApplication%2Fcluster-services%2Fgovuk-replatform-test-app%2F0&tab=manifest)
 
@@ -33,4 +33,4 @@ The govuk-helm-chart repository contains configuration for how an app is deploye
 
 1. Tidy up your `ENV_MESSAGE`
 
-    Revert your PR to tidy up the codebase and post it for review on the #govuk-replatforming-class channel. After your PR has been approved and passed status checks you can merge your PR to undo your changes.
+    Revert your PR to tidy up the codebase. After your PR has been approved and passed status checks you can merge your PR to undo your changes.

--- a/source/get-started/tutorials/app-update-deploy-monitor-logs/index.html.md
+++ b/source/get-started/tutorials/app-update-deploy-monitor-logs/index.html.md
@@ -5,7 +5,7 @@ last_reviewed_on: 2023-03-07
 review_in: 6 months
 ---
 
-# Deploy a new version of the example test app, check the deployment, monitor the app on grafana and view application logs
+# Deploy a new version of the example test app, check the deployment, monitor the app on Grafana and view application logs
 
 This tutorial will teach you how to deploy changes to an app and how to view application metrics and logs.
 
@@ -23,9 +23,9 @@ In this tutorial, you will make a change to the example test app to print your m
 
 1. See that the app changes have started the deployment
 
-    You can check the ["Deploy" GitHub Action workflow](https://github.com/alphagov/govuk-replatform-test-app/actions) to see that the deployment has begun. This workflow builds a new container image with your application changes, and then triggers an [Argo workflow](https://argo-workflows.eks.integration.govuk.digital/workflows/apps?limit=500) (login via Github SSO, if you can't see any workflows set the namespace to `apps`) to update the image tag stored in [govuk-helm-charts](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/app-config/image-tags/integration/govuk-replatform-test-app) repository.  
+    You can check the ["Deploy" GitHub Actions workflow](https://github.com/alphagov/govuk-replatform-test-app/actions) to see that the deployment has begun. This workflow builds a new container image with your application changes, and then triggers an [Argo Workflow](https://argo-workflows.eks.integration.govuk.digital/workflows/apps?limit=500) (login via Github SSO, if you can't see any workflows set the namespace to `apps`) to update the image tag stored in [govuk-helm-charts](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/app-config/image-tags/integration/govuk-replatform-test-app) repository.
 
-    This will make the [app in the cluster](https://argo.eks.integration.govuk.digital/applications/cluster-services/govuk-replatform-test-app?view=tree&orphaned=false&resource=&node=argoproj.io%2FApplication%2Fcluster-services%2Fgovuk-replatform-test-app%2F0) to be out of sync with the image tag on the govuk-helms-chart so Argo will attempt to redeploy the app to keep it in sync. The annotations `imageTag` sha should match the commit sha on the main branch of the test app repository, Argos is currently set to poll for changes every 2 minutes.
+    This will cause the [app in the cluster](https://argo.eks.integration.govuk.digital/applications/cluster-services/govuk-replatform-test-app?view=tree&orphaned=false&resource=&node=argoproj.io%2FApplication%2Fcluster-services%2Fgovuk-replatform-test-app%2F0) to be out of sync with the image tag in the govuk-helm-charts repo so Argo will attempt to redeploy the app to keep it in sync. The `imageTag=release-...` SHA against `ANNOTATIONS` should match the commit SHA on the main branch of the test app repository. Argo CD is currently set to poll the repository for changes every 2 minutes.
 
 1. Check your message on the example test app website
 
@@ -33,7 +33,7 @@ In this tutorial, you will make a change to the example test app to print your m
 
 1. View app metrics on the Grafana dashboard
 
-    Change the status parameter in the test app url to a 5xx status in order to see the error appearing in the [grafana dashboard](https://grafana.eks.integration.govuk.digital/d/000000111/app-request-rates-errors-durations?orgId=1&refresh=10s&var-namespace=apps&var-app=govuk-replatform-test-app&var-quantile=All&var-error_status=All) (login via your govuk Google SSO)
+    Change the status parameter in the test app url to a 5xx status in order to see the error appearing in the [Grafana dashboard](https://grafana.eks.integration.govuk.digital/d/000000111/app-request-rates-errors-durations?orgId=1&refresh=10s&var-namespace=apps&var-app=govuk-replatform-test-app&var-quantile=All&var-error_status=All) (login via your govuk Google SSO)
 
 1. View the messages in your text file in the logs
 
@@ -57,4 +57,4 @@ In this tutorial, you will make a change to the example test app to print your m
 
 ## Maintenance
 
-If you want to make changes to the test app please create a PR and send it to the `#govuk-replatforming` slack channel for review.
+If you want to make changes to the test app please raise a PR and someone from Platform Engineering team will pick it up.

--- a/source/manage-app/create-new-env/index.html.md
+++ b/source/manage-app/create-new-env/index.html.md
@@ -5,30 +5,19 @@ last_reviewed_on: 2022-07-01
 review_in: 6 months
 ---
 
+> 🚧 This document is outdated and untested. 🚧
+>
+> If you are thinking about creating an additional GOV.UK Kubernetes cluster, please get in touch with [#govuk-platform-engineering team] and we'll be happy to help you to achieve your goals.
+
 # Create a new environment
-
-You can create a new test, staging, integration or production environment on the GOV.UK Kubernetes platform.
-
-You create a new environment to, for example, work on new functionality or resources for the platform.
 
 To create a new environment, you must:
 
-- complete the prerequisites
 - create secrets for the new environment
 - create a new empty environment
 - deploy the Terraform modules
 - create the Signon API token
 - check the environment is working
-
-## Complete the prerequisites
-
-Before creating a new environment, you must:
-
-- [set up the tools needed to use the GOV.UK Kubernetes platform](/get-started/set-up-tools/#set-up-tools-to-use-the-gov-uk-kubernetes-platform)
-- [request a new AWS account](https://gds-request-an-aws-account.cloudapps.digital/)
-- [install the AWS-CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
-- [install Terraform](https://www.terraform.io/downloads)
-- [install the `gds-cli`](https://docs.publishing.service.gov.uk/manual/get-started.html#4-install-gds-command-line-tools), which you should have done already as part of [getting started on GOV.UK](https://docs.publishing.service.gov.uk/manual/get-started.html)
 
 ## Create secrets for the new environment
 
@@ -91,8 +80,6 @@ The [`ecr` module](https://github.com/alphagov/govuk-infrastructure/tree/main/te
       terraform apply -var-file ../variables/<ENVIRONMENT>/ecr.tfvars
     ```
     `<ENVIRONMENT>` is the environment type you defined in the earlier step.
-
-If you’re creating an integration or staging environment, you must [contact the GOV.UK replatforming team on Slack](https://gds.slack.com/archives/C013F737737) to discuss the impact of deploying the `ecr` module.
 
 ### 2. Deploy the `cluster-infrastructure` module
 
@@ -173,11 +160,11 @@ This allows Signon resources to create or export tokens from Signon.
 
 You should now have successfully created a new environment on the GOV.UK Kubernetes platform.
 
-To check the environment is working, go to the new environment URL endpoint at `“https://www.eks.<ENVIRONMENT>.govuk.digital`. For example, the endpoint for a new production environment is `https://www.eks.production.govuk.digital`.
+To check the environment is working, go to the new environment URL endpoint at `https://www.eks.<ENVIRONMENT>.govuk.digital`. For example, the endpoint for a new production environment is `https://www.eks.production.govuk.digital`.
 
 You must be in the office or on the VPN to access this endpoint.
 
-If the environment URL endpoint is not behaving as expected or shows an error, [contact the GOV.UK replatforming team on Slack](https://gds.slack.com/archives/C013F737737).
+If the environment URL endpoint is not behaving as expected or shows an error, contact [#govuk-platform-engineering team].
 
 ## Supporting information
 
@@ -186,3 +173,5 @@ When you create the new environment, the process will also create an instance of
 See the [Kubescape user hub](https://hub.armosec.io/docs/welcome-to-kubescape-user-hub) for more information.
 
 See also the [Kubernetes conceptual overview documentation](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) for more information on Kubernetes overall.
+
+[#govuk-platform-engineering team]: /contact-platform-engineering-team.html

--- a/source/manage-app/manage-secrets/index.html.md
+++ b/source/manage-app/manage-secrets/index.html.md
@@ -183,7 +183,7 @@ Now you can use the Kubernetes secret inside the app referring to it in the app'
 
 1. Save the `.yaml` file and merge the change.
 
-    If you are not sure how to define the secret in the `.yaml` file, [contact the GOV.UK replatforming team on Slack](https://gds.slack.com/archives/C013F737737).
+    If you are not sure how to define the secret in the `.yaml` file, ask [Platform Engineering team](/contact-platform-engineering-team.html) and we'll help you.
 
 ## Supporting information
 
@@ -193,5 +193,5 @@ The operator reads information from external APIs and automatically injects the 
 
 For more information, see the:
 
-- [External Secrets Operator documentation](https://external-secrets.io/v0.5.8/guides-introduction/)
+- [External Secrets Operator documentation](https://external-secrets.io/)
 - [External Secrets Operator GitHub repository](https://github.com/external-secrets/external-secrets)

--- a/source/manage-app/scale-app/index.html.md
+++ b/source/manage-app/scale-app/index.html.md
@@ -59,8 +59,8 @@ Most of the time, you should only need to scale the `appResources` and `workerRe
 
 ## How scaling your app affects platform resources
 
-If you increase the resources available to your app, this will increase the load on the virtual machines (VMs) that the platform runs on.
+The cluster will automatically scale up in response to demand from application workloads, subject to some overall limits.
 
-You should be aware of this increased load on the platform, and look out for any [Argo CD deployment notifications or alerts](https://argocd-notifications.readthedocs.io/en/stable/).
+Very large increases to resource requests or replica counts could run into those limits or have other implications.
 
-[Contact the GOV.UK Replatforming team by email](mailto:govuk-replatforming-team@digital.cabinet-office.gov.uk) to discuss how scaling your app's resources affects the platform and whether you need to scale the platform resources as well.
+[GOV.UK Platform Engineering team](/contact-platform-engineering-team.html) can help advise you on how best to meet your scalability needs. Please don't hesitate to get it touch if you're at all unsure.


### PR DESCRIPTION
Update the team name and contact details to reflect the recent name change. Put the team contact details on a single page (along with a bit of context about the sort of thing we do) so it might be slightly less hassle next time.

Also update a few outdated odds and ends along the way and stick a health hazard warning on the cluster turnup instructions for the time being (lest they lead some poor innocent soul astray).