### PR TITLE
Update workflow for publishing to GitHub Pages.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,17 @@
+---
 name: deploy
-on:
+"on":
   push:
-    branches:
-      - main
+    branches: [main]
+  workflow_dispatch:
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -22,5 +22,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
-          cname: govuk-k8s-user-docs.publishing.service.gov.uk
+          cname: govuk-kubernetes-cluster-user-docs.publishing.service.gov.uk
           commit_message: "Deploy via merge on main"


### PR DESCRIPTION
- Make the GitHub Pages custom domain match the repo name.
- Add workflow_dispatch so we can trigger it ad-hoc if need be.
- Update to current versions of actions.
- Fix YAML lints in the workflow definition.