### PR TITLE
Update initial setup documentation

### DIFF
--- a/source/get-started/access-eks-cluster/index.html.md
+++ b/source/get-started/access-eks-cluster/index.html.md
@@ -42,9 +42,7 @@ The readonly role:
 - has readonly access to a specific cluster in a specific environment
 - can view everything in that cluster excluding secrets
 
-1. Open the `gds-cli`.
-
-1. Run the following to export the AWS credentials for the appropriate GOV.UK environment and role:
+1. Run the following to export the AWS credentials into your shell environment for the appropriate GOV.UK environment and role:
 
   ```sh
   eval $(gds aws govuk-<govuk-environment>-<role> -e --art 8h)

--- a/source/get-started/set-up-tools/index.html.md
+++ b/source/get-started/set-up-tools/index.html.md
@@ -13,6 +13,7 @@ You must set up the following tools to use the GOV.UK Kubernetes platform:
 - Helm
 - Argo CLI to manage Argo Workflows
 - `gds-cli` and `aws-vault`
+- AWS CLI (`aws`)
 
 ## Install kubectl
 
@@ -146,3 +147,7 @@ v6.2.0
 ```
 
 See the [`aws-vault` README](https://github.com/99designs/aws-vault#readme) for more information on how to use `aws-vault`.
+
+### Install AWS CLI (`aws`)
+
+Install the [AWS CLI](https://aws.amazon.com/cli/). This is needed to export the EKS kubectl configuration into your `~/.kube/config`.


### PR DESCRIPTION
- Add installation of `aws` CLI to setup notes (required for initial kube config setup)
- Remove additional reference to opening `gds-cli`